### PR TITLE
gbm: lock and release buffer in swap buffers

### DIFF
--- a/src/waffle/gbm/wgbm_platform.c
+++ b/src/waffle/gbm/wgbm_platform.c
@@ -156,7 +156,7 @@ static const struct wcore_platform_vtbl wgbm_platform_vtbl = {
         .create = wgbm_window_create,
         .destroy = wgbm_window_destroy,
         .show = wgbm_window_show,
-        .swap_buffers = wegl_window_swap_buffers,
+        .swap_buffers = wgbm_window_swap_buffers,
         .get_native = wgbm_window_get_native,
     },
 };

--- a/src/waffle/gbm/wgbm_window.c
+++ b/src/waffle/gbm/wgbm_window.c
@@ -100,6 +100,23 @@ wgbm_window_show(struct wcore_window *wc_self)
     return true;
 }
 
+
+bool
+wgbm_window_swap_buffers(struct wcore_window *wc_self)
+{
+    if (!wegl_window_swap_buffers(wc_self))
+        return false;
+
+    struct wgbm_window *self = wgbm_window(wc_self);
+    struct gbm_bo *bo = gbm_surface_lock_front_buffer(self->gbm_surface);
+    if (!bo)
+        return false;
+
+    gbm_surface_release_buffer(self->gbm_surface, bo);
+    return true;
+}
+
+
 union waffle_native_window*
 wgbm_window_get_native(struct wcore_window *wc_self)
 {

--- a/src/waffle/gbm/wgbm_window.h
+++ b/src/waffle/gbm/wgbm_window.h
@@ -60,5 +60,8 @@ wgbm_window_destroy(struct wcore_window *wc_self);
 bool
 wgbm_window_show(struct wcore_window *wc_self);
 
+bool
+wgbm_window_swap_buffers(struct wcore_window *wc_self);
+
 union waffle_native_window*
 wgbm_window_get_native(struct wcore_window *wc_self);


### PR DESCRIPTION
Otherwise mesa prints "libEGL debug: EGL user error 0x300d (EGL_BAD_SURFACE) in dri2_swap_buffers"
when environment variable EGL_LOG_LEVEL=debug.

You can see this by running waffle's gl_basic example.  Every call to swap_buffers after the first one will cause this message to be printed.
Though an error message is printed, no harm is done and no error is returned.  I'm not sure why mesa does this, but assuming there's a reason, this lock/unlock seems to be what it wants us to do.
