### PR TITLE
wflinfo: use waffle_dl_sym to get glGetStringi

### DIFF
--- a/src/utils/wflinfo.c
+++ b/src/utils/wflinfo.c
@@ -1037,7 +1037,7 @@ main(int argc, char **argv)
     if (!glGetString)
         error_get_gl_symbol("glGetString");
 
-    glGetStringi = waffle_get_proc_address("glGetStringi");
+    glGetStringi = waffle_dl_sym(opts.dl, "glGetStringi");
 
     const struct wflinfo_config_attrs config_attrs = {
         .api = opts.context_api,


### PR DESCRIPTION
Wflinfo tries to use glGetStringi when the gl version >= 3.0, but
eglGetProcAddress cannot be relied on to get core functions like
glGetStringi unless the egl version is 1.5 or higher.  Dlsym works with
lower egl versions.  This lets wflinfo work on platforms where egl < 1.5
and gl >= 3.0, e.g. mali.
