### PR TITLE
[RFC] Implement the window.resize method on the gbm platform

### DIFF
--- a/src/waffle/egl/wegl_platform.c
+++ b/src/waffle/egl/wegl_platform.c
@@ -105,6 +105,7 @@ wegl_platform_init(struct wegl_platform *self)
     RETRIEVE_EGL_SYMBOL(eglBindAPI);
     RETRIEVE_EGL_SYMBOL(eglCreateContext);
     RETRIEVE_EGL_SYMBOL(eglDestroyContext);
+    RETRIEVE_EGL_SYMBOL(eglGetCurrentContext);
 
     // window
     RETRIEVE_EGL_SYMBOL(eglGetConfigAttrib);

--- a/src/waffle/egl/wegl_platform.h
+++ b/src/waffle/egl/wegl_platform.h
@@ -60,6 +60,7 @@ struct wegl_platform {
                                    EGLContext share_context,
                                    const EGLint *attrib_list);
     EGLBoolean (*eglDestroyContext)(EGLDisplay dpy, EGLContext ctx);
+    EGLContext (*eglGetCurrentContext)();
 
     // window
     EGLBoolean (*eglGetConfigAttrib)(EGLDisplay dpy, EGLConfig config,

--- a/src/waffle/egl/wegl_util.c
+++ b/src/waffle/egl/wegl_util.c
@@ -70,6 +70,26 @@ wegl_emit_error(struct wegl_platform *plat, const char *egl_func_call)
 }
 
 bool
+wegl_make_current2(struct wcore_platform *wc_plat,
+                   struct wcore_display *wc_dpy,
+                   struct wcore_window *wc_window,
+                   EGLContext wc_ctx)
+{
+    struct wegl_platform *plat = wegl_platform(wc_plat);
+    EGLSurface surface = wc_window ? wegl_window(wc_window)->egl : NULL;
+    bool ok;
+
+    ok = plat->eglMakeCurrent(wegl_display(wc_dpy)->egl,
+                              surface,
+                              surface,
+                              wc_ctx);
+    if (!ok)
+        wegl_emit_error(plat, "eglMakeCurrent");
+
+    return ok;
+}
+
+bool
 wegl_make_current(struct wcore_platform *wc_plat,
                   struct wcore_display *wc_dpy,
                   struct wcore_window *wc_window,

--- a/src/waffle/egl/wegl_util.h
+++ b/src/waffle/egl/wegl_util.h
@@ -41,6 +41,12 @@ void
 wegl_emit_error(struct wegl_platform *plat, const char *egl_func_call);
 
 bool
+wegl_make_current2(struct wcore_platform *wc_plat,
+                   struct wcore_display *wc_dpy,
+                   struct wcore_window *wc_window,
+                   EGLContext wc_ctx);
+
+bool
 wegl_make_current(struct wcore_platform *wc_plat,
                   struct wcore_display *wc_dpy,
                   struct wcore_window *wc_window,

--- a/src/waffle/gbm/wgbm_platform.c
+++ b/src/waffle/gbm/wgbm_platform.c
@@ -210,6 +210,7 @@ static const struct wcore_platform_vtbl wgbm_platform_vtbl = {
         .destroy = wgbm_window_destroy,
         .show = wgbm_window_show,
         .swap_buffers = wgbm_window_swap_buffers,
+        .resize = wgbm_window_resize,
         .get_native = wgbm_window_get_native,
     },
 };

--- a/src/waffle/gbm/wgbm_window.h
+++ b/src/waffle/gbm/wgbm_window.h
@@ -35,6 +35,7 @@ struct gbm_surface;
 struct wgbm_window {
     struct gbm_surface *gbm_surface;
     struct wegl_window wegl;
+    struct wcore_config *wc_config;
 };
 
 static inline struct wgbm_window*
@@ -64,6 +65,10 @@ wgbm_window_show(struct wcore_window *wc_self);
 
 bool
 wgbm_window_swap_buffers(struct wcore_window *wc_self);
+
+bool
+wgbm_window_resize(struct wcore_window *wc_self,
+                   int32_t width, int32_t height);
 
 union waffle_native_window*
 wgbm_window_get_native(struct wcore_window *wc_self);


### PR DESCRIPTION
This fixes apitrace’s bug #390, which made eglretrace unusable on this platform.

Since gbm has no support for surface resizing, we need to destroy and recreate the `gbm_surface`.  This requires tearing down and recreating the `EGLSurface` associated with it, which will unbind the current `EGLContext`.

I couldn’t find anywhere in Waffle how to retrieve the current `struct wcore_context *` in order to use it with `wegl_make_current`, so I had to duplicate this function to take an `EGLContext`.
Is there any better solution?  I’m not satisfied with this implementation at all.

Fixes https://github.com/apitrace/apitrace/issues/390
