### PR TITLE
wayland: Add support for wayland-scanner 1.10

### DIFF
--- a/src/waffle/wayland/wayland_wrapper.c
+++ b/src/waffle/wayland/wayland_wrapper.c
@@ -106,6 +106,7 @@ wayland_wrapper_init(void)
     RETRIEVE_WL_CLIENT_SYMBOL(wl_proxy_add_listener);
     RETRIEVE_WL_CLIENT_SYMBOL(wl_proxy_marshal);
     RETRIEVE_WL_CLIENT_SYMBOL(wl_proxy_marshal_constructor);
+    RETRIEVE_WL_CLIENT_SYMBOL(wl_proxy_marshal_constructor_versioned);
 #undef RETRIEVE_WL_CLIENT_SYMBOL
 
 error:

--- a/src/waffle/wayland/wayland_wrapper.h
+++ b/src/waffle/wayland/wayland_wrapper.h
@@ -75,6 +75,13 @@ struct wl_proxy *
                                     const struct wl_interface *interface,
                                     ...);
 
+struct wl_proxy *
+(*wfl_wl_proxy_marshal_constructor_versioned)(struct wl_proxy *proxy,
+                                              uint32_t opcode,
+                                              const struct wl_interface *interface,
+                                              uint32_t version,
+                                              ...);
+
 #ifdef _WAYLAND_CLIENT_H
 #error Do not include wayland-client.h ahead of wayland_wrapper.h
 #endif
@@ -92,3 +99,5 @@ struct wl_proxy *
 #define wl_proxy_add_listener (*wfl_wl_proxy_add_listener)
 #define wl_proxy_marshal (*wfl_wl_proxy_marshal)
 #define wl_proxy_marshal_constructor (*wfl_wl_proxy_marshal_constructor)
+#define wl_proxy_marshal_constructor_versioned \
+	(*wfl_wl_proxy_marshal_constructor_versioned)


### PR DESCRIPTION
wayland-scanner 1.10 and above use a new symbol, wl_proxy_marshal_constructor_versioned, which also needs to be caught and redirected by the wrapper.

The implementation could be a bit better, by checking the version of wayland-scanner through pkg-config, but couldn't see a way to do that (cmake is completely alien to me, and I gave up on the documentation after some time).

Fixes waffle-gl/waffle#38.