### PR TITLE
appveyor: Initial appveyor integration.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+version: '{build}'
+
+branches:
+  except:
+  - /^travis.*$/
+
+shallow_clone: true
+
+# https://www.appveyor.com/docs/build-environment/#build-worker-images
+os: Visual Studio 2015
+
+environment:
+  matrix:
+  - TOOLCHAIN: mingw32
+  - TOOLCHAIN: mingw64
+  - TOOLCHAIN: msvc32
+  - TOOLCHAIN: msvc64
+
+matrix:
+  fast_finish: true
+
+install:
+# Check CMake
+- cmake --version
+# Install Ninja
+- cinst -y ninja
+- ninja --version
+# Setup MinGW
+- if "%TOOLCHAIN%"=="mingw32" set MINGW_HOME=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32
+- if "%TOOLCHAIN%"=="mingw64" set MINGW_HOME=C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64
+- if not "%MINGW_HOME%"=="" set Path=%MINGW_HOME%\bin;%Path%
+# Setup MSVC
+- if "%TOOLCHAIN%"=="msvc32" set MSVC_ARCH=x86
+- if "%TOOLCHAIN%"=="msvc64" set MSVC_ARCH=x86_amd64
+- if not "%MSVC_ARCH%"=="" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %MSVC_ARCH%
+# Get OpenGL extension headers
+- mkdir glext\GL
+- appveyor DownloadFile https://www.khronos.org/registry/OpenGL/api/GL/glext.h -FileName glext\GL\glext.h
+- appveyor DownloadFile https://www.khronos.org/registry/OpenGL/api/GL/wglext.h -FileName glext\GL\wglext.h
+
+before_build:
+- if "%APPVEYOR_REPO_TAG%"=="true" (set BUILD_TYPE=RelWithDebInfo) else (set BUILD_TYPE=Debug)
+
+build_script:
+# XXX: tests fail to build with MSVC
+- cmake -H. -Bbuild -G "Ninja" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_INSTALL_PREFIX=%CD%\publish -DGLEXT_INCLUDE_DIR=%CD%\glext -Dwaffle_build_tests=0 -Dwaffle_build_examples=1
+- ninja -C build
+
+after_build:
+# XXX: Unfortunately the "package" doesn't work for Windows, because
+# cmake/Modules/GNUInstallDirs.cmake hardcodes absolute CMAKE_INSTALL_PREFIX
+# into a bunched of CMAKE_INSTALL_* cached vars that don't get updated when
+# installing to the archive scratch directory.
+#- ninja -C build package
+- ninja -C build install
+- 7z a waffle-%TOOLCHAIN%.7z publish
+
+artifacts:
+#- path: build/waffle1-*.zip
+- path: waffle-*.7z


### PR DESCRIPTION
It would be great if we could get automatic Windows builds of waffle, through AppVeyor to ensure build is always successful.  https://www.appveyor.com/ is free for open-source projects and it integrates well GitHub.

This PR integrates with AppVeyor to build Waffle for 32/64 bits Windows using both MinGW and MSVC.  You can see a sample build on https://ci.appveyor.com/project/jrfonseca/waffle/build/12

There are a few quirks -- see the XXX comments for details.

With an additional commit ac215785f43576e6c283699242d34b7f695479c0 one can even have AppVeyor automatically push the MSVC/MinGW binaries to Github releases, as shown in https://github.com/jrfonseca/waffle/releases/tag/appveyor-1.5.2  . But you can't just cherry-pick that commit -- if you're interested you'll need to follow the instructions https://www.appveyor.com/docs/deployment/github/ so you use a github auth token of your own for it to work.