### PR TITLE
gbm: Use modifiers to create the surface when available 

### DIFF
--- a/src/waffle/egl/wegl_display.c
+++ b/src/waffle/egl/wegl_display.c
@@ -89,6 +89,7 @@ get_extensions(struct wegl_display *dpy)
 
     CHECK_EXTENSION(EXT_create_context_robustness);
     CHECK_EXTENSION(KHR_create_context);
+    CHECK_EXTENSION(EXT_image_dma_buf_import_modifiers);
 
 #undef CHECK_EXTENSION
 

--- a/src/waffle/egl/wegl_display.c
+++ b/src/waffle/egl/wegl_display.c
@@ -84,8 +84,13 @@ get_extensions(struct wegl_display *dpy)
     // pending emission.
     assert(wcore_error_get_code() == 0);
 
-    dpy->EXT_create_context_robustness = waffle_is_extension_in_string(extensions, "EGL_EXT_create_context_robustness");
-    dpy->KHR_create_context = waffle_is_extension_in_string(extensions, "EGL_KHR_create_context");
+#define CHECK_EXTENSION(ext) \
+    dpy->ext = waffle_is_extension_in_string(extensions, "EGL_" #ext)
+
+    CHECK_EXTENSION(EXT_create_context_robustness);
+    CHECK_EXTENSION(KHR_create_context);
+
+#undef CHECK_EXTENSION
 
     return true;
 }

--- a/src/waffle/egl/wegl_display.h
+++ b/src/waffle/egl/wegl_display.h
@@ -45,6 +45,7 @@ struct wegl_display {
     enum wegl_supported_api api_mask;
     bool EXT_create_context_robustness;
     bool KHR_create_context;
+    bool EXT_image_dma_buf_import_modifiers;
     EGLint major_version;
     EGLint minor_version;
 };

--- a/src/waffle/egl/wegl_platform.c
+++ b/src/waffle/egl/wegl_platform.c
@@ -172,6 +172,10 @@ wegl_platform_init(struct wegl_platform *self, EGLenum egl_platform)
     // EGL_EXT_platform_display
     RETRIEVE_EGL_SYMBOL_OPTIONAL(eglGetPlatformDisplayEXT);
 
+    // EGL_EXT_image_dma_buf_import_modifiers
+    RETRIEVE_EGL_SYMBOL_OPTIONAL(eglQueryDmaBufFormatsEXT);
+    RETRIEVE_EGL_SYMBOL_OPTIONAL(eglQueryDmaBufModifiersEXT);
+
 #undef RETRIEVE_EGL_SYMBOL
 #undef RETRIEVE_EGL_SYMBOL_OPTIONAL
 

--- a/src/waffle/egl/wegl_platform.h
+++ b/src/waffle/egl/wegl_platform.h
@@ -97,6 +97,17 @@ struct wegl_platform {
     // EGL_EXT_platform_display
     EGLDisplay (*eglGetPlatformDisplayEXT)(EGLenum platform, void *native_display,
                                            const EGLint *attrib_list);
+
+    // EGL_EXT_image_dma_buf_import_modifiers
+    EGLBoolean (*eglQueryDmaBufFormatsEXT)(EGLDisplay dpy,
+                                           EGLint max_formats,
+                                           EGLint *formats,
+                                           EGLint *num_formats);
+    EGLBoolean (*eglQueryDmaBufModifiersEXT)(EGLDisplay dpy, EGLint format,
+                                             EGLint max_modifiers,
+                                             EGLuint64KHR *modifiers,
+                                             EGLBoolean *external_only,
+                                             EGLint *num_modifiers);
 };
 
 DEFINE_CONTAINER_CAST_FUNC(wegl_platform,

--- a/src/waffle/gbm/wgbm_platform.c
+++ b/src/waffle/gbm/wgbm_platform.c
@@ -100,9 +100,9 @@ wgbm_platform_init(struct wgbm_platform *self)
         goto error;
     }
 
-#define RETRIEVE_GBM_SYMBOL(type, function, args)                                  \
+#define RETRIEVE_GBM_SYMBOL(type, function, required, args)            \
     self->function = dlsym(self->gbmHandle, #function);                \
-    if (!self->function) {                                             \
+    if (required && !self->function) {                                 \
         wcore_errorf(WAFFLE_ERROR_FATAL,                             \
                      "dlsym(\"%s\", \"" #function "\") failed: %s",    \
                      libgbm_filename, dlerror());                      \

--- a/src/waffle/gbm/wgbm_platform.h
+++ b/src/waffle/gbm/wgbm_platform.h
@@ -35,13 +35,13 @@
 #include "wcore_util.h"
 
 #define GBM_FUNCTIONS(f) \
-    f(struct gbm_device * , gbm_create_device            , (int fd)) \
-    f(int                 , gbm_device_get_fd            , (struct gbm_device *dev)) \
-    f(void                , gbm_device_destroy           , (struct gbm_device *gbm)) \
-    f(struct gbm_surface *, gbm_surface_create           , (struct gbm_device *gbm, uint32_t width, uint32_t height, uint32_t format, uint32_t flags)) \
-    f(void                , gbm_surface_destroy          , (struct gbm_surface *surface)) \
-    f(struct gbm_bo *     , gbm_surface_lock_front_buffer, (struct gbm_surface *surface)) \
-    f(void                , gbm_surface_release_buffer   , (struct gbm_surface *surface, struct gbm_bo *bo))
+    f(struct gbm_device * , gbm_create_device                   ,  true, (int fd)) \
+    f(int                 , gbm_device_get_fd                ,  true, (struct gbm_device *dev)) \
+    f(void                , gbm_device_destroy               ,  true, (struct gbm_device *gbm)) \
+    f(struct gbm_surface *, gbm_surface_create               ,  true, (struct gbm_device *gbm, uint32_t width, uint32_t height, uint32_t format, uint32_t flags)) \
+    f(void                , gbm_surface_destroy              ,  true, (struct gbm_surface *surface)) \
+    f(struct gbm_bo *     , gbm_surface_lock_front_buffer    ,  true, (struct gbm_surface *surface)) \
+    f(void                , gbm_surface_release_buffer       ,  true, (struct gbm_surface *surface, struct gbm_bo *bo))
 
 struct linux_platform;
 
@@ -52,7 +52,7 @@ struct wgbm_platform {
     // GBM function pointers
     void *gbmHandle;
 
-#define DECLARE(type, function, args) type (*function) args;
+#define DECLARE(type, function, required, args) type (*function) args;
     GBM_FUNCTIONS(DECLARE)
 #undef DECLARE
 };

--- a/src/waffle/gbm/wgbm_platform.h
+++ b/src/waffle/gbm/wgbm_platform.h
@@ -41,7 +41,8 @@
     f(struct gbm_surface *, gbm_surface_create               ,  true, (struct gbm_device *gbm, uint32_t width, uint32_t height, uint32_t format, uint32_t flags)) \
     f(void                , gbm_surface_destroy              ,  true, (struct gbm_surface *surface)) \
     f(struct gbm_bo *     , gbm_surface_lock_front_buffer    ,  true, (struct gbm_surface *surface)) \
-    f(void                , gbm_surface_release_buffer       ,  true, (struct gbm_surface *surface, struct gbm_bo *bo))
+    f(void                , gbm_surface_release_buffer       ,  true, (struct gbm_surface *surface, struct gbm_bo *bo)) \
+    f(struct gbm_surface *, gbm_surface_create_with_modifiers, false, (struct gbm_device *gbm, uint32_t width, uint32_t height, uint32_t format, const uint64_t *modifiers, const unsigned int count))
 
 struct linux_platform;
 


### PR DESCRIPTION
This little PR implements GBM modifier support for waffle.  When both the needed GBM entrypoint and EGL extension are available, we get a list of modifiers from EGL and use `gbm_create_surface_with_modifiers` to create the surface.  This should allow for much better piglit test coverage of modifiers.