### PR TITLE
tests/gl_basic: Fix compilation for surfaceless_egl

### DIFF
--- a/tests/functional/gl_basic_test.c
+++ b/tests/functional/gl_basic_test.c
@@ -656,7 +656,8 @@ test_glesXX(3, 30, NO_ERROR)
     defined(WAFFLE_HAS_GLX) || \
     defined(WAFFLE_HAS_WAYLAND) || \
     defined(WAFFLE_HAS_X11_EGL) || \
-    defined(WAFFLE_HAS_WGL)
+    defined(WAFFLE_HAS_WGL) || \
+    defined(WAFFLE_HAS_SURFACELESS_EGL)
 
 test_XX_fwdcompat(gles1, OPENGL_ES1, ERROR_BAD_ATTRIBUTE)
 test_XX_fwdcompat(gles2, OPENGL_ES2, ERROR_BAD_ATTRIBUTE)
@@ -712,7 +713,7 @@ CREATE_TESTSUITE(WAFFLE_PLATFORM_SURFACELESS_EGL, surfaceless_egl)
 
 #undef unit_test_make
 
-#endif // WAFFLE_HAS_GBM
+#endif // WAFFLE_HAS_SURFACELESS_EGL
 
 #ifdef WAFFLE_HAS_WAYLAND
 


### PR DESCRIPTION
If the only platform selected is surfaceless_egl test_gl_basic_glesX_fwdcompat
is not defined which make compiler unhappy:
--------------------------------------->8-------------------------------------
.../tests/functional/gl_basic_test.c:581:24: error: 'test_gl_basic_gles2_fwdcompat' undeclared (first use in this function); did you mean 'test_gl_basic_gles1_fwdcompat'?
         unit_test_make(test_gl_basic_gles2_fwdcompat),                  \
                        ^
--------------------------------------->8-------------------------------------

Not really sure to which extent fwdcompact is supported in
surfaceless_egl but an educated guess is it's pretty much the same as
for GBM.

Also while at it fixing wrong comment.

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
Cc: Gurchetan Singh <gurchetansingh@chromium.org>
Cc: Emil Velikov <emil.l.velikov@gmail.com>
Cc: Chad Versace <chadversary@chromium.org>
Cc: Erico Nunes <nunes.erico@gmail.com>
Cc: Haixia Shi <hshi@chromium.org>