### PR TITLE
Add QNX support

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -38,6 +38,10 @@ if(waffle_on_linux)
     set(nacl_version "pepper_39" CACHE STRING "Set NaCl bundle here")
 endif()
 
+if(waffle_on_qnx)
+    option(waffle_has_qnx "Build support for QNX" ON)
+endif()
+
 option(waffle_build_tests "Build tests" ON)
 option(waffle_build_manpages "Build manpages" OFF)
 option(waffle_build_htmldocs "Build html documentation" OFF)

--- a/cmake/Modules/WaffleDefineCompilerFlags.cmake
+++ b/cmake/Modules/WaffleDefineCompilerFlags.cmake
@@ -144,3 +144,7 @@ endif()
 if(waffle_on_windows)
     add_definitions(-DWAFFLE_HAS_WGL)
 endif()
+
+if(waffle_on_qnx)
+    add_definitions(-DWAFFLE_HAS_QNX -D_QNX_SOURCE)
+endif()

--- a/cmake/Modules/WaffleDefineCompilerFlags.cmake
+++ b/cmake/Modules/WaffleDefineCompilerFlags.cmake
@@ -60,7 +60,9 @@ if (NOT MSVC)
     endif()
 
     if(egl_FOUND)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${egl_CFLAGS_OTHER}")
+        foreach(FLAG ${egl_CFLAGS_OTHER})
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG}")
+        endforeach()
     endif(egl_FOUND)
 
     if(MINGW)

--- a/cmake/Modules/WaffleDefineInternalOptions.cmake
+++ b/cmake/Modules/WaffleDefineInternalOptions.cmake
@@ -1,5 +1,5 @@
 if(waffle_has_wayland OR waffle_has_x11_egl OR waffle_has_gbm OR
-   waffle_has_surfaceless_egl)
+   waffle_has_surfaceless_egl OR waffle_has_qnx)
     set(waffle_has_egl TRUE)
 else()
     set(waffle_has_egl FALSE)

--- a/cmake/Modules/WaffleDefineOS.cmake
+++ b/cmake/Modules/WaffleDefineOS.cmake
@@ -22,13 +22,14 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set(waffle_on_linux true)
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     set(waffle_on_mac true)
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
     set(waffle_on_windows true)
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "QNX")
+    set(waffle_on_qnx true)
 else()
     message(FATAL_ERROR "Unrecognized CMAKE_SYSTEM_NAME=\"${CMAKE_SYSTEM_NAME}\"")
 endif()

--- a/examples/gl_basic.c
+++ b/examples/gl_basic.c
@@ -62,7 +62,7 @@ removeXcodeArgs(int *argc, char **argv);
 
 static const char *usage_message =
     "usage:\n"
-    "    gl_basic --platform=android|cgl|gbm|glx|wayland|wgl|x11_egl\n"
+    "    gl_basic --platform=android|cgl|gbm|glx|wayland|wgl|x11_egl|qnx\n"
     "             --api=gl|gles1|gles2|gles3\n"
     "             [--version=MAJOR.MINOR]\n"
     "             [--profile=core|compat|none]\n"
@@ -263,6 +263,7 @@ static const struct enum_map platform_map[] = {
     {WAFFLE_PLATFORM_WAYLAND,   "wayland"       },
     {WAFFLE_PLATFORM_WGL,       "wgl"           },
     {WAFFLE_PLATFORM_X11_EGL,   "x11_egl"       },
+    {WAFFLE_PLATFORM_QNX,       "qnx"           },
     {0,                         0               },
 };
 

--- a/examples/gl_basic.c
+++ b/examples/gl_basic.c
@@ -434,7 +434,7 @@ error_unrecognized_arg:
 // This function hides that complexity with a naive heuristic: try, then try
 // again.
 static void *
-get_gl_symbol(const struct options *opts, const const char *name)
+get_gl_symbol(const struct options *opts, const char *name)
 {
     void *sym = NULL;
 

--- a/include/waffle/waffle.h
+++ b/include/waffle/waffle.h
@@ -120,6 +120,7 @@ enum waffle_enum {
         WAFFLE_PLATFORM_WGL                                     = 0x0017,
         WAFFLE_PLATFORM_NACL                                    = 0x0018,
         WAFFLE_PLATFORM_SURFACELESS_EGL                         = 0x0019,
+        WAFFLE_PLATFORM_QNX                                     = 0x001a,
 
     // ------------------------------------------------------------------
     // For waffle_config_choose()

--- a/src/utils/wflinfo.c
+++ b/src/utils/wflinfo.c
@@ -65,7 +65,7 @@ static const char *usage_message =
     "Required Parameters:\n"
     "    -p, --platform <platform>\n"
     "        One of: android, cgl, gbm, glx, surfaceless_egl (or short\n"
-    "        alias 'sl'), wayland, wgl, or x11_egl.\n"
+    "        alias 'sl'), wayland, wgl, qnx or x11_egl.\n"
     "\n"
     "    -a, --api <api>\n"
     "        One of: gl, gles1, gles2 or gles3\n"
@@ -292,6 +292,7 @@ static const struct enum_map platform_map[] = {
     {WAFFLE_PLATFORM_X11_EGL,   "x11_egl"       },
     {WAFFLE_PLATFORM_SURFACELESS_EGL,   "surfaceless_egl" },
     {WAFFLE_PLATFORM_SURFACELESS_EGL,   "sl"              },
+    {WAFFLE_PLATFORM_QNX,       "qnx"           },
     {0,                         0               },
 };
 

--- a/src/waffle/CMakeLists.txt
+++ b/src/waffle/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
     glx
     linux
     nacl
+    qnx
     surfaceless_egl
     wayland
     wgl
@@ -32,6 +33,7 @@ include_directories(
     ${wayland-egl_INCLUDE_DIRS}
     ${x11-xcb_INCLUDE_DIRS}
     )
+
 
 # ----------------------------------------------------------------------------
 # Target: waffle (shared library)
@@ -196,6 +198,21 @@ if(waffle_has_nacl)
         )
     list(APPEND waffle_cxx_sources
         nacl/nacl_container.cpp
+        )
+endif()
+
+if(waffle_on_qnx)
+    list(APPEND waffle_sources
+        qnx/qnx_display.c
+        qnx/qnx_platform.c
+        qnx/qnx_window.c
+        qnx/qnx_display_priv.c
+        qnx/qnx_window_priv.c
+        linux/linux_dl.c
+        linux/linux_platform.c
+        )
+    list(APPEND waffle_libdeps
+        screen
         )
 endif()
 

--- a/src/waffle/api/waffle_init.c
+++ b/src/waffle/api/waffle_init.c
@@ -37,6 +37,7 @@ struct wcore_platform* wgbm_platform_create(void);
 struct wcore_platform* wgl_platform_create(void);
 struct wcore_platform* nacl_platform_create(void);
 struct wcore_platform* sl_platform_create(void);
+struct wcore_platform* qnx_platform_create(void);
 
 static bool
 waffle_init_parse_attrib_list(
@@ -118,6 +119,12 @@ waffle_init_parse_attrib_list(
                     CASE_UNDEFINED_PLATFORM(SURFACELESS_EGL)
 #endif
 
+#ifdef WAFFLE_HAS_QNX
+                    CASE_DEFINED_PLATFORM(QNX)
+#else
+                    CASE_UNDEFINED_PLATFORM(QNX)
+#endif
+
                     default:
                         wcore_errorf(WAFFLE_ERROR_BAD_ATTRIBUTE,
                                      "WAFFLE_PLATFORM has bad value 0x%x",
@@ -195,6 +202,11 @@ waffle_init_create_platform(int32_t waffle_platform)
 #ifdef WAFFLE_HAS_SURFACELESS_EGL
         case WAFFLE_PLATFORM_SURFACELESS_EGL:
             wc_platform = sl_platform_create();
+            break;
+#endif
+#ifdef WAFFLE_HAS_QNX
+        case WAFFLE_PLATFORM_QNX:
+            wc_platform = qnx_platform_create();
             break;
 #endif
         default:

--- a/src/waffle/egl/wegl_config.c
+++ b/src/waffle/egl/wegl_config.c
@@ -109,7 +109,7 @@ check_context_attrs(struct wegl_display *dpy,
         case WAFFLE_CONTEXT_OPENGL_ES3:
             if (!(dpy->api_mask & WEGL_OPENGL_ES_API)) {
                 wcore_errorf(WAFFLE_ERROR_UNSUPPORTED_ON_PLATFORM,
-                             "eglQueryString(EGL_CLIENT_APIS) does not"
+                             "eglQueryString(EGL_CLIENT_APIS) does not "
                              "advertise OpenGL_ES.");
                 return false;
             }

--- a/src/waffle/egl/wegl_platform.c
+++ b/src/waffle/egl/wegl_platform.c
@@ -57,6 +57,8 @@ setup_env(const struct wegl_platform *self)
         case EGL_PLATFORM_SURFACELESS_MESA:
             setenv("EGL_PLATFORM", "surfaceless", true);
             break;
+        case EGL_NONE:
+            break;
         default:
             assert(!"bad egl_platform enum");
             break;
@@ -217,6 +219,9 @@ wegl_platform_can_use_eglGetPlatformDisplay(const struct wegl_platform *plat)
         case EGL_PLATFORM_SURFACELESS_MESA:
             ext = "EGL_MESA_platform_surfaceless";
             break;
+        case EGL_NONE:
+            ext = NULL;
+            break;
         default:
             assert(!"bad egl_platform enum");
             return false;
@@ -248,6 +253,9 @@ wegl_platform_can_use_eglGetPlatformDisplayEXT(const struct wegl_platform *plat)
             break;
         case EGL_PLATFORM_SURFACELESS_MESA:
             ext = "EGL_MESA_platform_surfaceless";
+            break;
+        case EGL_NONE:
+            ext = NULL;
             break;
         default:
             assert(!"bad egl_platform enum");

--- a/src/waffle/linux/linux_platform.c
+++ b/src/waffle/linux/linux_platform.c
@@ -36,12 +36,26 @@ struct linux_platform {
     struct linux_dl *libgl;
     struct linux_dl *libgles1;
     struct linux_dl *libgles2;
+    struct linux_platform_libs *lib_names;
 };
 
 struct linux_platform*
 linux_platform_create(void)
 {
     return wcore_calloc(sizeof(struct linux_platform));
+}
+
+struct linux_platform*
+linux_platform_create2(struct linux_platform_libs *lib_names)
+{
+    struct linux_platform *self;
+
+    self = wcore_calloc(sizeof(*self));
+    if (self == NULL)
+        return NULL;
+
+    self->lib_names = lib_names;
+    return self;
 }
 
 bool
@@ -76,8 +90,13 @@ linux_platform_get_dl(struct linux_platform *self, int32_t waffle_dl)
             return NULL;
     }
 
-    if (*dl == NULL)
-        *dl = linux_dl_open(waffle_dl);
+    if (*dl == NULL) {
+        if (self->lib_names == NULL) {
+            *dl = linux_dl_open(waffle_dl);
+        } else {
+            *dl = linux_dl_open2(waffle_dl, self->lib_names);
+        }
+    }
 
     return *dl;
 }

--- a/src/waffle/linux/linux_platform.h
+++ b/src/waffle/linux/linux_platform.h
@@ -29,9 +29,13 @@
 #include <stdint.h>
 
 struct linux_platform;
+struct linux_platform_libs;
 
 struct linux_platform*
 linux_platform_create(void);
+
+struct linux_platform*
+linux_platform_create2(struct linux_platform_libs *libs);
 
 bool
 linux_platform_destroy(struct linux_platform *self);

--- a/src/waffle/linux/linux_platform_libs.h
+++ b/src/waffle/linux/linux_platform_libs.h
@@ -23,27 +23,11 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/// @file
-/// @brief Handlers for dynamic libraries on Linux, with error handling.
-
 #pragma once
 
-#include <stdbool.h>
-#include <stdint.h>
-
-struct linux_dl;
-struct linux_platform_libs;
-
-/// @brief Dynamically open an OpenGL library.
-/// @a waffle_dl must be one of `WAFFLE_DL_*`.
-struct linux_dl*
-linux_dl_open(int32_t waffle_dl);
-
-struct linux_dl*
-linux_dl_open2(int32_t waffle_dl, struct linux_platform_libs *lib_names);
-
-bool
-linux_dl_close(struct linux_dl *self);
-
-void*
-linux_dl_sym(struct linux_dl *self, const char *symbol);
+struct linux_platform_libs {
+    const char *libgl;
+    const char *libgles1;
+    const char *libgles2;
+    const char *libgles3;
+};

--- a/src/waffle/qnx/qnx_display.c
+++ b/src/waffle/qnx/qnx_display.c
@@ -1,0 +1,75 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "linux_platform.h"
+#include "qnx_platform.h"
+#include "wegl_platform.h"
+#include "qnx_display.h"
+#include "qnx_display_priv.h"
+
+struct wcore_display*
+qnx_display_connect(struct wcore_platform *wc_plat,
+                    const char *name)
+{
+    bool ok = true;
+    struct qnx_display *self;
+
+    (void) name;
+
+    self = wcore_calloc(sizeof(*self));
+    if (self == NULL)
+        return NULL;
+
+    self->priv = qnx_display_priv_create();
+    if (self->priv == NULL)
+        goto error;
+
+    ok = wegl_display_init(&self->wegl, wc_plat, EGL_DEFAULT_DISPLAY);
+    if (!ok)
+        goto error;
+
+    return &self->wegl.wcore;
+
+error:
+    qnx_display_disconnect(&self->wegl.wcore);
+    return NULL;
+}
+
+bool
+qnx_display_disconnect(struct wcore_display *wc_self)
+{
+    bool ok = true;
+    struct qnx_display *self = qnx_display(wegl_display(wc_self));
+
+    if (!self)
+        return ok;
+
+    qnx_display_priv_destroy(self->priv);
+
+    ok &= wegl_display_teardown(&self->wegl);
+    free(self);
+
+    return ok;
+}

--- a/src/waffle/qnx/qnx_display.h
+++ b/src/waffle/qnx/qnx_display.h
@@ -1,0 +1,48 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "wegl_display.h"
+
+struct qnx_display_priv;
+
+struct qnx_display {
+    struct wegl_display wegl;
+    struct qnx_display_priv *priv;
+};
+DEFINE_CONTAINER_CAST_FUNC(qnx_display,
+                           struct qnx_display,
+                           struct wegl_display,
+                           wegl)
+
+struct wcore_display*
+qnx_display_connect(struct wcore_platform *wc_plat,
+                    const char *name);
+
+bool
+qnx_display_disconnect(struct wcore_display *wc_self);

--- a/src/waffle/qnx/qnx_display_priv.c
+++ b/src/waffle/qnx/qnx_display_priv.c
@@ -1,0 +1,79 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "wcore_util.h"
+#include "wcore_error.h"
+#include "qnx_display_priv.h"
+
+struct qnx_display_priv*
+qnx_display_priv_create(void)
+{
+    int ndisplays = 0;
+    int rc;
+    struct qnx_display_priv *self;
+
+    self = wcore_calloc(sizeof(*self));
+    if (self == NULL)
+        return NULL;
+
+    rc = screen_create_context(&self->screen_ctx, SCREEN_APPLICATION_CONTEXT);
+    if (rc != 0) {
+        wcore_error_errno("screen_create_context failed");
+        goto error;
+    }
+
+    rc = screen_get_context_property_iv(self->screen_ctx,
+                                        SCREEN_PROPERTY_DISPLAY_COUNT,
+                                        &ndisplays
+                                       );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_DISPLAY_COUNT failed");
+        goto error;
+    }
+
+    return self;
+error:
+    qnx_display_priv_destroy(self);
+    return NULL;
+}
+
+bool
+qnx_display_priv_destroy(struct qnx_display_priv* self)
+{
+    int rc = 0;
+
+    if (!self)
+        return true;
+
+    rc = screen_destroy_context(self->screen_ctx);
+    if (rc != 0) {
+        wcore_error_errno("screen_destroy_context failed");
+    }
+
+    free(self);
+    return (rc == 0);
+}

--- a/src/waffle/qnx/qnx_display_priv.h
+++ b/src/waffle/qnx/qnx_display_priv.h
@@ -1,0 +1,38 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <screen/screen.h>
+
+struct qnx_display_priv {
+    screen_context_t screen_ctx;
+};
+
+struct qnx_display_priv*
+qnx_display_priv_create(void);
+
+bool
+qnx_display_priv_destroy(struct qnx_display_priv*);

--- a/src/waffle/qnx/qnx_platform.c
+++ b/src/waffle/qnx/qnx_platform.c
@@ -1,0 +1,131 @@
+#include "wegl_context.h"
+#include "wegl_util.h"
+#include "linux_platform.h"
+#include "linux_platform_libs.h"
+#include "wegl_config.h"
+#include "wegl_platform.h"
+#include "qnx_display.h"
+#include "qnx_platform.h"
+#include "qnx_window.h"
+
+static const struct wcore_platform_vtbl qnx_platform_vtbl;
+
+static bool
+qnx_platform_destroy(struct wcore_platform *wc_self)
+{
+    struct qnx_platform *self = qnx_platform(wegl_platform(wc_self));
+    bool ok = true;
+
+    if (!self)
+        return true;
+
+    if (self->linux)
+        ok &= linux_platform_destroy(self->linux);
+
+    ok &= wcore_platform_teardown(wc_self);
+
+    free(self);
+    return ok;
+}
+
+struct wcore_platform*
+qnx_platform_create(void)
+{
+    struct linux_platform_libs lib_names = { .libgl = NULL,
+                                             .libgles1 = "libGLESv1_CM.so",
+                                             .libgles2 = "libGLESv2_viv.so",
+                                             .libgles3 = "libGLESv2_viv.so"
+                                           };
+    struct qnx_platform *self;
+    bool ok = true;
+
+    self = wcore_calloc(sizeof(*self));
+    if (self == NULL)
+        return NULL;
+
+    ok = wegl_platform_init(&self->wegl, EGL_NONE);
+    if (!ok)
+        goto error;
+
+    self->linux = linux_platform_create2(&lib_names);
+    if (self->linux == NULL)
+        goto error;
+
+    self->wegl.wcore.vtbl = &qnx_platform_vtbl;
+    return &self->wegl.wcore;
+
+error:
+    qnx_platform_destroy(&self->wegl.wcore);
+    return NULL;
+}
+
+static bool
+qnx_platform_dl_can_open(struct wcore_platform *wc_self,
+                         int32_t waffle_dl)
+{
+    return linux_platform_dl_can_open(qnx_platform(wegl_platform(wc_self))->linux,
+                                      waffle_dl);
+}
+
+static void*
+qnx_platform_dl_sym(struct wcore_platform *wc_self,
+                    int32_t waffle_dl,
+                    const char *name)
+{
+    return linux_platform_dl_sym(qnx_platform(wegl_platform(wc_self))->linux,
+                                 waffle_dl, name);
+}
+
+static bool
+qnx_display_supports_context_api(struct wcore_display *wc_self,
+                                 int32_t context_api)
+{
+    switch (context_api) {
+        case WAFFLE_CONTEXT_OPENGL_ES2:
+        case WAFFLE_CONTEXT_OPENGL_ES3:
+            return true;
+        case WAFFLE_CONTEXT_OPENGL:
+        case WAFFLE_CONTEXT_OPENGL_ES1:
+            return false;
+        default:
+            assert(false);
+            return false;
+    }
+}
+
+static const struct wcore_platform_vtbl qnx_platform_vtbl = {
+    .destroy = qnx_platform_destroy,
+
+    .make_current = wegl_make_current,
+    .get_proc_address = wegl_get_proc_address,
+    .dl_can_open = qnx_platform_dl_can_open,
+    .dl_sym = qnx_platform_dl_sym,
+
+    .display = {
+        .connect = qnx_display_connect,
+        .destroy = qnx_display_disconnect,
+        .supports_context_api = qnx_display_supports_context_api,
+        .get_native = NULL,
+    },
+
+    .config = {
+        .choose = wegl_config_choose,
+        .destroy = wegl_config_destroy,
+        .get_native = NULL,
+    },
+
+    .context = {
+        .create = wegl_context_create,
+        .destroy = wegl_context_destroy,
+        .get_native = NULL,
+    },
+
+    .window = {
+        .create = qnx_window_create,
+        .destroy = qnx_window_destroy,
+        .show = qnx_window_show,
+        .swap_buffers = wegl_surface_swap_buffers,
+        .resize = qnx_window_resize,
+        .get_native = NULL,
+    },
+};

--- a/src/waffle/qnx/qnx_platform.h
+++ b/src/waffle/qnx/qnx_platform.h
@@ -1,0 +1,43 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "waffle.h"
+#include "wcore_util.h"
+#include "wcore_platform.h"
+#include "wegl_platform.h"
+
+struct qnx_platform {
+    struct wegl_platform wegl;
+    struct linux_platform *linux;
+};
+DEFINE_CONTAINER_CAST_FUNC(qnx_platform,
+                           struct qnx_platform,
+                           struct wegl_platform,
+                           wegl)
+
+struct wcore_platform*
+qnx_platform_create(void);

--- a/src/waffle/qnx/qnx_window.c
+++ b/src/waffle/qnx/qnx_window.c
@@ -1,0 +1,107 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "wcore_attrib_list.h"
+#include "wcore_error.h"
+#include "wegl_config.h"
+#include "wegl_surface.h"
+#include "qnx_display.h"
+#include "qnx_display_priv.h"
+#include "qnx_window.h"
+#include "qnx_window_priv.h"
+
+struct wcore_window*
+qnx_window_create(struct wcore_platform *wc_plat,
+                  struct wcore_config *wc_config,
+                  int32_t width,
+                  int32_t height,
+                  const intptr_t attrib_list[])
+{
+    struct qnx_display *dpy = qnx_display(wegl_display(wc_config->display));
+    struct qnx_window *self;
+
+    if (wcore_attrib_list_length(attrib_list) > 0) {
+        wcore_error_bad_attribute(attrib_list[0]);
+    }
+
+    self = wcore_calloc(sizeof(*self));
+    if (self == NULL)
+        return NULL;
+
+    self->priv = qnx_window_priv_create(dpy, width, height);
+    if (self->priv == NULL)
+        goto error;
+
+    bool ok = wegl_window_init(&self->wegl, wc_config,
+                          (intptr_t) *((intptr_t*)(&self->priv->screen_win)));
+    if (!ok)
+        goto error;
+
+    return &self->wegl.wcore;
+
+error:
+    qnx_window_destroy(&self->wegl.wcore);
+    return NULL;
+}
+
+bool
+qnx_window_destroy(struct wcore_window *wc_self)
+{
+    bool ok = true;
+    struct qnx_window *self = qnx_window(wegl_surface(wc_self));
+
+    if (self == NULL)
+        return ok;
+
+    ok &= wegl_surface_teardown(&self->wegl);
+    ok &= qnx_window_priv_destroy(self->priv);
+
+    free(self);
+    return ok;
+}
+
+bool
+qnx_window_show(struct wcore_window *wc_self)
+{
+    struct qnx_window *self = qnx_window(wegl_surface(wc_self));
+
+    if (self == NULL)
+        return true;
+
+    return qnx_window_priv_show(self->priv);
+}
+
+bool
+qnx_window_resize(struct wcore_window *wc_self,
+                  int32_t width,
+                  int32_t height)
+{
+    struct qnx_window *self = qnx_window(wegl_surface(wc_self));
+
+    if (self == NULL)
+        return true;
+
+    return qnx_window_priv_resize(self->priv, width, height);
+}

--- a/src/waffle/qnx/qnx_window.h
+++ b/src/waffle/qnx/qnx_window.h
@@ -1,0 +1,58 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <stdbool.h>
+#include "wegl_surface.h"
+
+struct qnx_window_priv;
+
+struct qnx_window {
+    struct wegl_surface wegl;
+    struct qnx_window_priv *priv;
+};
+DEFINE_CONTAINER_CAST_FUNC(qnx_window,
+                           struct qnx_window,
+                           struct wegl_surface,
+                           wegl)
+
+struct wcore_window*
+qnx_window_create(struct wcore_platform *wc_plat,
+                  struct wcore_config *wc_config,
+                  int32_t width,
+                  int32_t height,
+                  const intptr_t attrib_list[]);
+
+bool
+qnx_window_destroy(struct wcore_window *wc_self);
+
+bool
+qnx_window_show(struct wcore_window *wc_self);
+
+bool
+qnx_window_resize(struct wcore_window *wc_self,
+                  int32_t width,
+                  int32_t height);

--- a/src/waffle/qnx/qnx_window_priv.c
+++ b/src/waffle/qnx/qnx_window_priv.c
@@ -1,0 +1,207 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "wcore_error.h"
+#include "wcore_attrib_list.h"
+#include "wegl_config.h"
+#include "qnx_display.h"
+#include "qnx_window_priv.h"
+#include "qnx_display_priv.h"
+
+struct qnx_window_priv*
+qnx_window_priv_create(struct qnx_display *dpy,
+                       int32_t width,
+                       int32_t height)
+{
+    struct qnx_window_priv *self;
+
+    int rc;
+    const int format = SCREEN_FORMAT_RGB565;
+    const int usage = SCREEN_USAGE_OPENGL_ES2 | SCREEN_USAGE_OPENGL_ES3;
+    const int position[] = { 0, 0};
+    const int size[] = {width, height};
+    const int nbuffers = 2;
+    const int interval = 1;
+    const int transparency = SCREEN_TRANSPARENCY_NONE;
+
+    self = wcore_calloc(sizeof(*self));
+    if (self == NULL)
+        return NULL;
+
+    rc = screen_create_window(&self->screen_win, dpy->priv->screen_ctx);
+    if (rc != 0) {
+        wcore_error_errno("screen_create_window failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_FORMAT,
+                                       &format
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_FORMAT failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_USAGE,
+                                       &usage
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_USAGE failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_POSITION,
+                                       &position[0]
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_POSITION failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_SIZE,
+                                       size
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_SIZE failed");
+        goto error;
+    }
+
+    rc = screen_create_window_buffers(self->screen_win,
+                                      nbuffers
+                                     );
+    if (rc != 0) {
+        wcore_error_errno("screen_create_window_buffers failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_SWAP_INTERVAL,
+                                       &interval
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_SWAP_INTERVAL failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_TRANSPARENCY,
+                                       &transparency
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_TRANSPARENCY failed");
+        goto error;
+    }
+
+    return self;
+error:
+    qnx_window_priv_destroy(self);
+    return NULL;
+}
+
+bool
+qnx_window_priv_destroy(struct qnx_window_priv *self)
+{
+    int rc;
+
+    if (self == NULL)
+        return true;
+
+    rc = screen_destroy_window(self->screen_win);
+    if (rc !=0 ) {
+        wcore_error_errno("screen_destroy_window failed");
+    }
+
+    free(self);
+    return (rc == 0);
+}
+
+bool
+qnx_window_priv_show(struct qnx_window_priv *self)
+{
+    int rc;
+    const int is_visible = 1;
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_VISIBLE,
+                                       &is_visible
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_VISIBLE failed");
+        goto error;
+    }
+
+    return true;
+error:
+    return false;
+}
+
+bool
+qnx_window_priv_resize(struct qnx_window_priv *self,
+                       int32_t width,
+                       int32_t height)
+ {
+    int rc;
+    const int size[] = {width, height};
+    const int nbuffers = 2;
+    const int transparency = SCREEN_TRANSPARENCY_NONE;
+
+    rc = screen_destroy_window_buffers(self->screen_win);
+    if (rc != 0) {
+        wcore_error_errno("screen_destroy_window_buffers failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_SIZE,
+                                       size
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_SIZE failed");
+        goto error;
+    }
+
+    rc = screen_create_window_buffers(self->screen_win, nbuffers);
+    if (rc != 0) {
+        wcore_error_errno("screen_create_window_buffers failed");
+        goto error;
+    }
+
+    rc = screen_set_window_property_iv(self->screen_win,
+                                       SCREEN_PROPERTY_TRANSPARENCY,
+                                       &transparency
+                                      );
+    if (rc != 0) {
+        wcore_error_errno("SCREEN_PROPERTY_TRANSPARENCY failed");
+        goto error;
+    }
+
+    return true;
+error:
+    return false;
+}

--- a/src/waffle/qnx/qnx_window_priv.h
+++ b/src/waffle/qnx/qnx_window_priv.h
@@ -1,0 +1,52 @@
+// Copyright 2014 Intel Corporation
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <screen/screen.h>
+
+struct qnx_window_priv {
+    screen_window_t screen_win;
+};
+
+struct wcore_platform;
+struct wcore_config;
+struct qnx_display;
+
+struct qnx_window_priv*
+qnx_window_priv_create(struct qnx_display *wc_config,
+                       int32_t width,
+                       int32_t height);
+
+bool
+qnx_window_priv_destroy(struct qnx_window_priv *wc_self);
+
+bool
+qnx_window_priv_show(struct qnx_window_priv *wc_self);
+
+bool
+qnx_window_priv_resize(struct qnx_window_priv *wc_self,
+                       int32_t width,
+                       int32_t height);

--- a/third_party/threads/threads.h
+++ b/third_party/threads/threads.h
@@ -86,7 +86,7 @@ typedef struct once_flag_t {
 } once_flag;
 #endif
 
-#elif defined(__unix__) || defined(__unix)
+#elif defined(__unix__) || defined(__unix) || defined(__QNX__)
 #include <pthread.h>
 
 /*---------------------------- macros ----------------------------*/


### PR DESCRIPTION
The patch set begins by fixing some minor issues, unrelated to QNX.
Then, new functions are added to linux_platform for specifying GL library names; this is done to avoid
adding ifdefs for lib names.

I've found a case where eglGetPlatformDisplay is available as a library symbol,
but there's no EGL_PLATFORM_ enum for it, so it returns EGL_NONE.

The rest of the patch set adds a QNX screen platform,
and makes the new backend available to wflinfo and examples.